### PR TITLE
bugfix in cosinus distance calculation

### DIFF
--- a/string_distance/token_distance.pyx
+++ b/string_distance/token_distance.pyx
@@ -65,7 +65,7 @@ cdef float binary_cosine(dict source, dict target):
 cdef float cosine(dict source, dict target):
     cdef float source_norm = norm(source)
     cdef float target_norm = norm(target)
-    cdef float norm_ = source_norm + target_norm
+    cdef float norm_ = source_norm * target_norm
     cdef float intersection = 0
     for k, v in source.items():
         if k in target:

--- a/tests/token_distance_test.py
+++ b/tests/token_distance_test.py
@@ -7,6 +7,12 @@ def test_cosine_and_binary_different():
     assert cosine_distance(source, target) != binary_cosine_distance(source, target)
 
 
+def test_cosine_equality():
+    for i in range(2, 7):
+        word = ''.join(str(n) for n in range(i))
+        assert math.isclose(cosine_distance(word, word), 0, abs_tol=1e-6)
+
+
 def test_jaccard():
     source = "abcd"
     target = "abddef"


### PR DESCRIPTION
In the denominator, the magnitudes (norms) are being added instead of multiplied.

This shows pretty well for equal strings of different length:
```py
>>> for i in range(2, 7):
...     word = ''.join(str(n) for n in range(i))
...     print(cosine_distance(word, word))
... 
0.5
0.2928932309150696
0.13397455215454102
0.0
-0.1180340051651001
```

With the fix, the numbers are (close to) what they should be:
```py
>>> for i in range(2, 7):
...     word = ''.join(str(n) for n in range(i))
...     print(cosine_distance(word, word))
... 
0.0
-1.1920928955078125e-07
0.0
0.0
0.0
```